### PR TITLE
Python 2 human readable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ To run this script, pass the file you want to have analyzed as first parameter:
 python mwc.py myfile.md
 ```
 
+Since this script requires version 3, you might need to run that version specifically:
+
+```
+python3 mwc.py myfile.md
+```
+
 ## ⛏ Development
 
 Run this to execute all tests:

--- a/mwc.py
+++ b/mwc.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import re
 import sys

--- a/mwc.py
+++ b/mwc.py
@@ -30,6 +30,10 @@ def count_words_in_markdown(markdown):
 
 
 if __name__ == '__main__':
+    if sys.version_info < (3,):
+        print("Python 3 is required. You are using Python 2. You should probably run this script as follows:\npython3 mwc.py")
+        sys.exit(1)
+
     if len(sys.argv) < 2:
         print('Provide the file to parse as first argument')
         sys.exit(1)


### PR DESCRIPTION
I ran the script — per instructions in the README — as `python mwc.py`, but I have both version 2 and 3 installed. As I'm sure many people have I have python 3 as "python3" specifically.

Running this script with version 2 just gives a syntax error:

```
File "mwc.py", line 22
SyntaxError: Non-ASCII character '\xe2' in file mwc.py on line 22, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

This pull request fixes that by checking the version in the script, and printing a human readable error. Also updated the README with some info about this.
