### PR TITLE
Remove header ids before removing newlines

### DIFF
--- a/mwc.py
+++ b/mwc.py
@@ -17,10 +17,10 @@ def count_words_in_markdown(markdown):
     text = re.sub(r'^\[[^]]*\][^(].*', '', text, flags=re.MULTILINE)
     # Indented blocks of code
     text = re.sub(r'^( {4,}[^-*]).*', '', text, flags=re.MULTILINE)
-    # Replace newlines with spaces for uniform handling
-    text = text.replace('\n', ' ')
     # Custom header IDs
     text = re.sub(r'{#.*}', '', text)
+    # Replace newlines with spaces for uniform handling
+    text = text.replace('\n', ' ')
     # Remove images
     text = re.sub(r'!\[[^\]]*\]\([^)]*\)', '', text)
     # Remove HTML tags


### PR DESCRIPTION
I used the script for a markdown file similar to  this:
```
## header1 {#header1}
a lot of text
## header2 {#header2}
```

Unfortunately, the regex for "Custom header IDs" has matched with the beginning of the header ID at header1 and with the end of header ID at header 2. As a result, the whole section in between has been removed.

Changing the order and remove the header IDs before removing the newlines has solved it. The dot `.` matches only with all chars except the newline. With the change, we can make sure it only matches with custom IDs written in one row.