### PR TITLE
Simplify running by making script executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ To run this script, pass the file you want to have analyzed as the first paramet
 ./mwc.py myfile.md
 ```
 
-If that doesn't work, use:
+If that doesn't work, explicitely pass the program to Python:
 
 ```
-python3 mwc.py myfile.md
+python mwc.py myfile.md
 ```
+
+If this doesn't work, try `python3` instead of `python`.
 
 ## ⛏ Development
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ You will need...
 
 ## ▶ Usage
 
-To run this script, pass the file you want to have analyzed as first parameter:
+To run this script, pass the file you want to have analyzed as the first parameter:
 
 ```
-python mwc.py myfile.md
+./mwc.py myfile.md
 ```
 
-Since this script requires version 3, you might need to run that version specifically:
+If that doesn't work, use:
 
 ```
 python3 mwc.py myfile.md

--- a/mwc.py
+++ b/mwc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
 import re


### PR DESCRIPTION
Allow using just `./mwc.py myfile.md` instead of `python3 mwc.py myfile.md`.

This is shorter to type, and makes the script work when placed in `~/bin/`.