### PR TITLE
Add option to check markdowns inside folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ python mwc/cli.py myfile.md
 
 If this doesn't work, try `python3` instead of `python`.
 
+Or try `python -m mwc.cli myfile.md`
+
 ## ⛏ Development
 
 Run this to execute all tests:

--- a/mwc/cli.py
+++ b/mwc/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-from os.path import join, isfile, isdir
+from os.path import join, isfile, isdir, exists
 from os import listdir
 import os
 import sys
@@ -18,15 +18,28 @@ def main():
         print('Provide the Markdown file or folder to parse as first argument')
         sys.exit(1)
 
+    if not exists(sys.argv[1]):
+        print('File or folder not found.')
+        sys.exit(1)
+
     if isdir(sys.argv[1]):
-        allfiles = [join(sys.argv[1], f) for f in listdir(sys.argv[1]) if isfile(join(sys.argv[1], f)) and f.endswith(".md")]
+        allfiles = [join(sys.argv[1], f) for f in listdir(sys.argv[1]) if isfile(join(sys.argv[1], f)) and f.endswith('.md')]
+        allfiles.sort()
+        response = str()
         for file in allfiles:
             with open(file, 'r', encoding='utf8') as f:
-                print(file, count_words_in_markdown(f.read()))
-        return 0
+                r = '{0} - {1}\n'.format(file, count_words_in_markdown(f.read()))
+                response += r
+        print(response)
+        return response
 
     with open(sys.argv[1], 'r', encoding='utf8') as f:
-        print(count_words_in_markdown(f.read()))
+        if not sys.argv[1].endswith('.md'):
+            print('The file provided in the first argument is not a Markdown file.')
+            sys.exit(1)
+        response = '{0} - {1}'.format(sys.argv[1], count_words_in_markdown(f.read()))
+        print(response)
+        return response
 
 
 if __name__ == '__main__':

--- a/mwc/cli.py
+++ b/mwc/cli.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+from os.path import join, isfile, isdir
+from os import listdir
 import os
 import sys
 
@@ -13,12 +15,15 @@ def main():
         sys.exit(1)
 
     if len(sys.argv) < 2:
-        print('Provide the Markdown file to parse as first argument')
+        print('Provide the Markdown file or folder to parse as first argument')
         sys.exit(1)
 
-    if not os.path.isfile(sys.argv[1]):
-        print('The file at the given location could not be opened')
-        sys.exit(1)
+    if isdir(sys.argv[1]):
+        allfiles = [join(sys.argv[1], f) for f in listdir(sys.argv[1]) if isfile(join(sys.argv[1], f)) and f.endswith(".md")]
+        for file in allfiles:
+            with open(file, 'r', encoding='utf8') as f:
+                print(file, count_words_in_markdown(f.read()))
+        return 0
 
     with open(sys.argv[1], 'r', encoding='utf8') as f:
         print(count_words_in_markdown(f.read()))

--- a/tests/test_mwc.py
+++ b/tests/test_mwc.py
@@ -1,12 +1,15 @@
+import os
+import sys
+import shutil
+
 import textwrap
 from unittest import TestCase
 
 from mwc.counter import count_words_in_markdown
 from mwc.cli import main
-import sys
 
 try:
-    # python 3.4+ should use builtin unittest.mock not mock package
+    # Python 3.4+ should use builtin unittest.mock not mock package
     from unittest.mock import patch
 except ImportError:
     from mock import patch
@@ -14,11 +17,47 @@ except ImportError:
 
 class TestMWC(TestCase):
 
-    def test_singlefile(self):
-        testargs = ["mwc.cli", "teste"]
+    def test_single_markdown_file(self):
+        # Test single markdown file
+        with open("test.md", "w+") as f:
+            f.write("this is a markdown file!")
+        testargs = ["mwc.cli", "test.md"]
         with patch.object(sys, 'argv', testargs):
-            teste = main()
-            self.assertEqual(teste, "/home/fenton/project/setup.py")
+            test = main()
+            self.assertEqual(test, "test.md - 5")
+        os.remove("test.md")
+
+    def test_single_python_file(self):
+        # Test when user passes a file that isn't markdown
+        with open("test.py", "w+") as f:
+            f.write("print('hello world')")
+        testargs = ["mwc.cli", "test.py"]
+        with patch.object(sys, 'argv', testargs):
+            with self.assertRaises(SystemExit):
+                test = main()
+        os.remove("test.py")
+
+    def test_folder_with_markdown_files(self):
+        # Test multiple files in folder
+        if os.path.exists("test"):
+            shutil.rmtree("test")
+        os.mkdir("test")
+        with open("test/test1.md", "w+") as f:
+            f.write("this is a markdown file!")
+        with open("test/test2.md", "w+") as f:
+            f.write("this is a markdown file number 2!")
+        testargs = ["mwc.cli", "test"]
+        with patch.object(sys, 'argv', testargs):
+            test = main()
+            self.assertEqual(test, "test/test1.md - 5\ntest/test2.md - 7\n")
+        shutil.rmtree("test")
+
+    def test_file_does_not_exist(self):
+        # Test if program works when file or folder doesn't exist
+        testargs = ["mwc.cli", "something.md"]
+        with patch.object(sys, 'argv', testargs):
+            with self.assertRaises(SystemExit):
+                test = main()
 
     def test_simple_text(self):
         text = textwrap.dedent("""

--- a/tests/test_mwc.py
+++ b/tests/test_mwc.py
@@ -2,9 +2,24 @@ import textwrap
 from unittest import TestCase
 
 from mwc.counter import count_words_in_markdown
+from mwc.cli import main
+import sys
+
+try:
+    # python 3.4+ should use builtin unittest.mock not mock package
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 class TestMWC(TestCase):
+
+    def test_singlefile(self):
+        testargs = ["mwc.cli", "teste"]
+        with patch.object(sys, 'argv', testargs):
+            teste = main()
+            self.assertEqual(teste, "/home/fenton/project/setup.py")
+
     def test_simple_text(self):
         text = textwrap.dedent("""
         test a b    c


### PR DESCRIPTION
Add option to check all markdown files inside a specific folder. We've (@emmenezes and I) included tests. Currently it's not recursive due to many changes in single PR.

Also it was added a file verification (previously it was counting any type of file with text)
Also also, the print was changed to display the file name 

closes #14 