### PR TITLE
Add multiple files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Then, you'll be able to analyze any file by passing it's name (relative path) to
 mwc yourfile.md
 ```
 
+You can also pass in multiple files or a blob if your shell supports it:
+
+```
+mwc text1.md text2.md
+mwc test/*.md
+```
+
 ### Manually
 
 If you want to clone the repo and run the Python script manually, run:
@@ -47,4 +54,4 @@ python -m unittest discover
 
 ## 💬 Ports to Other Programming Languages
 
-* A PHP port can be found [here](https://github.com/Arcesilas/md-word-count), with thanks to [@Arcesilas](https://github.com/Arcesilas)!
+- A PHP port can be found [here](https://github.com/Arcesilas/md-word-count), with thanks to [@Arcesilas](https://github.com/Arcesilas)!

--- a/mwc/cli.py
+++ b/mwc/cli.py
@@ -5,6 +5,17 @@ import sys
 
 from mwc.counter import count_words_in_markdown
 
+def get_count(files):
+    count = 0
+    for file in files:
+        if not os.path.isfile(file):
+            print('The file at the given location {file} could not be opened')
+            sys.exit(1)
+        with open(file, 'r', encoding='utf8') as f:
+            count += count_words_in_markdown(f.read())
+
+    return count
+
 
 def main():
     if sys.version_info < (3,):
@@ -18,13 +29,7 @@ def main():
 
     files = sys.argv[1:]
 
-    count = 0
-    for file in files:
-        if not os.path.isfile(file):
-            print('The file at the given location {file} could not be opened')
-            sys.exit(1)
-        with open(file, 'r', encoding='utf8') as f:
-            count += count_words_in_markdown(f.read())
+    count = get_count(files)
 
     if len(files) == 1:
         print(f"Number of words in file {files[0]}")
@@ -32,6 +37,8 @@ def main():
     else:
         print(f"Words across {len(files)} files")
         print(count)
+        
+    return count
 
 
 if __name__ == '__main__':

--- a/mwc/cli.py
+++ b/mwc/cli.py
@@ -16,12 +16,22 @@ def main():
         print('Provide the Markdown file to parse as first argument')
         sys.exit(1)
 
-    if not os.path.isfile(sys.argv[1]):
-        print('The file at the given location could not be opened')
-        sys.exit(1)
+    files = sys.argv[1:]
 
-    with open(sys.argv[1], 'r', encoding='utf8') as f:
-        print(count_words_in_markdown(f.read()))
+    count = 0
+    for file in files:
+        if not os.path.isfile(file):
+            print('The file at the given location {file} could not be opened')
+            sys.exit(1)
+        with open(file, 'r', encoding='utf8') as f:
+            count += count_words_in_markdown(f.read())
+
+    if len(files) == 1:
+        print(f"Number of words in file {files[0]}")
+        print(count)
+    else:
+        print(f"Words across {len(files)} files")
+        print(count)
 
 
 if __name__ == '__main__':

--- a/tests/test_mwc.py
+++ b/tests/test_mwc.py
@@ -1,7 +1,19 @@
+import os
+import sys
+import shutil
+import io
+
 import textwrap
 from unittest import TestCase
 
 from mwc.counter import count_words_in_markdown
+from mwc.cli import main, get_count
+
+try:
+    # Python 3.4+ should use builtin unittest.mock not mock package
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 
 class TestMWC(TestCase):
@@ -13,20 +25,10 @@ class TestMWC(TestCase):
         testargs = ["mwc.cli", "test.md"]
         with patch.object(sys, 'argv', testargs):
             test = main()
-            self.assertEqual(test, "test.md - 5")
+            self.assertEqual(test, 5)
         os.remove("test.md")
 
-    def test_single_python_file(self):
-        # Test when user passes a file that isn't markdown
-        with open("test.py", "w+") as f:
-            f.write("print('hello world')")
-        testargs = ["mwc.cli", "test.py"]
-        with patch.object(sys, 'argv', testargs):
-            with self.assertRaises(SystemExit):
-                test = main()
-        os.remove("test.py")
-
-    def test_folder_with_markdown_files(self):
+    def test_multiple_markdown_files(self):
         # Test multiple files in folder
         if os.path.exists("test"):
             shutil.rmtree("test")
@@ -35,10 +37,10 @@ class TestMWC(TestCase):
             f.write("this is a markdown file!")
         with open("test/test2.md", "w+") as f:
             f.write("this is a markdown file number 2!")
-        testargs = ["mwc.cli", "test"]
+        testargs = ["mwc.cli", "test/test1.md", "test/test2.md"]
         with patch.object(sys, 'argv', testargs):
             test = main()
-            self.assertEqual(test, "test/test1.md - 5\ntest/test2.md - 7\n")
+            self.assertEqual(test, 12)
         shutil.rmtree("test")
 
     def test_file_does_not_exist(self):

--- a/tests/test_mwc.py
+++ b/tests/test_mwc.py
@@ -5,6 +5,49 @@ from mwc.counter import count_words_in_markdown
 
 
 class TestMWC(TestCase):
+    
+    def test_single_markdown_file(self):
+        # Test single markdown file
+        with open("test.md", "w+") as f:
+            f.write("this is a markdown file!")
+        testargs = ["mwc.cli", "test.md"]
+        with patch.object(sys, 'argv', testargs):
+            test = main()
+            self.assertEqual(test, "test.md - 5")
+        os.remove("test.md")
+
+    def test_single_python_file(self):
+        # Test when user passes a file that isn't markdown
+        with open("test.py", "w+") as f:
+            f.write("print('hello world')")
+        testargs = ["mwc.cli", "test.py"]
+        with patch.object(sys, 'argv', testargs):
+            with self.assertRaises(SystemExit):
+                test = main()
+        os.remove("test.py")
+
+    def test_folder_with_markdown_files(self):
+        # Test multiple files in folder
+        if os.path.exists("test"):
+            shutil.rmtree("test")
+        os.mkdir("test")
+        with open("test/test1.md", "w+") as f:
+            f.write("this is a markdown file!")
+        with open("test/test2.md", "w+") as f:
+            f.write("this is a markdown file number 2!")
+        testargs = ["mwc.cli", "test"]
+        with patch.object(sys, 'argv', testargs):
+            test = main()
+            self.assertEqual(test, "test/test1.md - 5\ntest/test2.md - 7\n")
+        shutil.rmtree("test")
+
+    def test_file_does_not_exist(self):
+        # Test if program works when file or folder doesn't exist
+        testargs = ["mwc.cli", "something.md"]
+        with patch.object(sys, 'argv', testargs):
+            with self.assertRaises(SystemExit):
+                test = main()
+                
     def test_simple_text(self):
         text = textwrap.dedent("""
         test a b    c


### PR DESCRIPTION
Allows passing multiple files into the command (and blobs like `*.md`) and adds some extra output.